### PR TITLE
Update dependency package for Google Colab

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ certifi==2024.2.2
 charset-normalizer==3.3.2
 click==8.1.7
 cloudpickle==3.0.0
+dash==2.9.3
+dash-bootstrap-components==1.4.1
 decorator==5.1.1
 distlib==0.3.8
 dm-tree==0.1.8
@@ -35,6 +37,7 @@ lz4==4.3.3
 markdown-it-py==3.0.0
 Markdown==3.6
 MarkupSafe==2.1.5
+matplotlib==3.7.1
 mdurl==0.1.2
 ml-dtypes==0.4.0
 mpmath==1.3.0
@@ -46,7 +49,7 @@ opt-einsum==3.3.0
 opyplus==1.4.2
 packaging==24.0
 pandas==1.5.3
-pettingzoo==1.22.2
+pettingzoo==1.25.0
 pillow==10.3.0
 platformdirs==3.11.0
 protobuf==4.25.3
@@ -71,7 +74,7 @@ scipy==1.13.0
 setproctitle==1.3.3
 shellingham==1.5.4
 six==1.16.0
-SuperSuit==3.7.0
+SuperSuit==3.9.3
 sympy==1.12
 tabulate==0.9.0
 tensorboard-data-server==0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ opt-einsum==3.3.0
 opyplus==1.4.2
 packaging==24.0
 pandas==1.5.3
-pettingzoo==1.25.0
+pettingzoo==1.24.3
 pillow==10.3.0
 platformdirs==3.11.0
 protobuf==4.25.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ Gymnasium==0.29.1
 h5py==3.10.0
 idna==3.6
 imageio==2.34.0
-jax==0.4.26
+jax[cpu]>=0.4.26
 Jinja2==3.1.3
 jsonschema-specifications==2023.12.1
 jsonschema==4.21.1
@@ -59,7 +59,7 @@ python-dateutil==2.9.0.post0
 python-slugify==3.0.6
 pytz==2024.1
 PyYAML==6.0.1
-ray==2.24.0
+ray==2.20.0
 referencing==0.34.0
 requests-oauthlib==2.0.0
 requests==2.31.0
@@ -78,7 +78,7 @@ tensorboard-data-server==0.7.2
 tensorboard==2.12.3
 tensorboardX==2.6.2.2
 tensorflow-estimator==2.12.0
-tensorflow-io-gcs-filesystem==0.36.0
+tensorflow-io-gcs-filesystem==0.31.0
 tensorflow-probability==0.20.0
 tensorflow==2.12.0
 termcolor==2.4.0


### PR DESCRIPTION
Now Google Colab only support Python 3.11, a virtual .env with Python=3.10 is needed. 

#Create a virtual env
!pip install virtualenv
!virtualenv -p python3.10 myenv
!source myenv/bin/activate && python --version

#Install packages
!myenv/bin/pip install -r requirements.txt

#Run the train model
!myenv/bin/python /content/dc-rl/train_sustaindc.py
